### PR TITLE
Remove old connection to pool if the refresh metadata remove the broker

### DIFF
--- a/src/KafkaNetClient/Interfaces/IBrokerRouter.cs
+++ b/src/KafkaNetClient/Interfaces/IBrokerRouter.cs
@@ -54,8 +54,8 @@ namespace KafkaNet
         /// Get the last refresh time in UTC
         /// </summary>
         /// <param name="topic"></param>
-        /// <returns></returns>
-        DateTime GetTopicMetadataRefreshTime(string topic);
+        /// <returns>return UTC DateTime of the last Refresh Metadata or null if the topic not exist in cache</returns>
+        DateTime? GetTopicMetadataRefreshTime(string topic);
 
         IKafkaLog Log { get; }
     }

--- a/src/KafkaNetClient/Interfaces/IBrokerRouter.cs
+++ b/src/KafkaNetClient/Interfaces/IBrokerRouter.cs
@@ -46,11 +46,15 @@ namespace KafkaNet
         /// <remarks>
         /// This method will initiate a call to the kafka servers and retrieve metadata for all given topics, updating the broke cache in the process.
         /// </remarks>
-
         Task<bool> RefreshTopicMetadata(params string[] topics);
 
         Task RefreshMissingTopicMetadata(params string[] topics);
 
+        /// <summary>
+        /// Get the last refresh time in UTC
+        /// </summary>
+        /// <param name="topic"></param>
+        /// <returns></returns>
         DateTime GetTopicMetadataRefreshTime(string topic);
 
         IKafkaLog Log { get; }


### PR DESCRIPTION
New case here.
When a server down, the Metadatacache do not drop old connection to server.